### PR TITLE
Output File Changes

### DIFF
--- a/Plugins/Import-Computers.ps1
+++ b/Plugins/Import-Computers.ps1
@@ -23,10 +23,6 @@ Script Usage
 
 Import-Hosts.ps1 -FilePath C:\Tools\Power-Response\Hosts.txt
 
-Parameter Use (In other Power-Response plugins)
-
-Set [Parameter Name from Plugin] global:ComputerName
-
 
 .NOTES
     Author: 5yn@x
@@ -46,8 +42,8 @@ param (
 
     )
 
-process{
+process {
 
-    $global:ComputerName = Import-CSV $FilePath | Select -ExpandProperty ComputerName
+    $global:PowerResponse.Parameters.ComputerName = Import-CSV $FilePath | Select -ExpandProperty ComputerName
 
     }


### PR DESCRIPTION
Changed default behavior for handling plugin output to throw it away.

Output now is entirely dependent on the Plugin to handle.

Added string parameters `ComputerName` and `Directory` to `Out-PRFile` for a more organized Output directory.

Split off separate function `Protect-PRFile` to set the IsReadOnly and log a hash of a file.