### PR TITLE
Fixed double digit number warning

### DIFF
--- a/Power-Response.ps1
+++ b/Power-Response.ps1
@@ -601,7 +601,7 @@ function Invoke-PRCommand {
         $Arguments = $UserInput -Split ' ' | Select-Object -Skip 1
 
         # If no $Keyword is not provided or we have no $global:PowerResponse.Location and were provided a number return early
-        if (!$Keyword -or ($global:PowerResponse.Location.PSIsContainer -and $Keyword -Match '^[0-9]$')) {
+        if (!$Keyword -or ($global:PowerResponse.Location.PSIsContainer -and $Keyword -Match '^[0-9]+$')) {
             return
         }
 


### PR DESCRIPTION
Fixed the digit regular expression in `Invoke-PRCommand` for parsing menu selections.