### PR TITLE
Collect-Items.ps1

### DIFF
--- a/Plugins/Analysis/Analyze-RecentFiles.ps1
+++ b/Plugins/Analysis/Analyze-RecentFiles.ps1
@@ -1,0 +1,99 @@
+<#
+
+.SYNOPSIS
+    Plugin-Name: Analyze-RecentItems.ps1
+    
+.Description
+    Analyzes recovered lnk files from recent items for all hosts that you have collected data from.
+    There are checks built in to not analyze twice. By default, the plugin will look for 
+    recent items results from the current date. You can specify the analysis date with the
+    $AnalyzeDate parameter. When using the $AnalyzeDate parameter, you must put your
+    date in the format of yyyyMMdd.
+
+    Dependencies
+    LECmd.exe (From Eric Zimmerman's Tools. stored in the Power-Response Bin directory)
+
+.EXAMPLE
+    
+    Power-Response Execution
+
+    For current date Analysis just execute 'run'
+
+    To specify a date
+
+    set AnalyzeDate 20190309
+    run
+
+.NOTES
+    Author: Drew Schmitt
+    Date Created: 3/12/2019
+    Twitter: @5ynax
+    
+    Last Modified By:
+    Last Modified Date:
+    Twitter:
+  
+#>
+
+param (
+
+    [Parameter(Mandatory=$false,Position=0)]
+    [DateTime]$AnalyzeDate= (Get-Date)
+
+    )
+
+process{
+
+    #Format String Properly for use
+    $AnalysisDate = ($AnalyzeDate.ToString('yyyy-MM-dd'))
+
+    #Verify that bin dependencies are met
+    $TestBin = Test-Path "{0}\LECmd.exe" -f $global:PowerResponse.Config.Path.Bin
+
+    if (!$TestBin){
+
+        Throw "LECmd not found in {0}. Place executable in binary directory and try again." -f $global:PowerResponse.Config.Path.Bin
+    }
+
+    #Build list of hosts that have been analyzed with Power-Response
+    $Machines = Get-ChildItem $global:PowerResponse.OutputPath
+
+    #Loop through and analyze prefetch files, while skipping if the analysis directory exists
+    foreach ($Machine in $Machines){
+        #Path to verify for existence before processing prefetch
+        $RecentItemsPath = ("{0}\{1}\{2}\RecentItems\") -f $global:PowerResponse.OutputPath,$Machine,$AnalysisDate
+        
+        #Get Users that have recent items data collected
+        $Users = Get-ChildItem $RecentItemsPath
+
+        foreach ($User in $Users){
+
+            #Path to data
+            $RecentItemsData = "$RecentItemsPath\$User"
+
+            #Determine if prefetch output directory exists
+            if (Test-Path $RecentItemsData){
+
+                #Verify that prefetch has not already been analyzed
+                $RecentItemsProcessed = "$RecentItemsData\Analysis\"
+
+                if (!(Test-Path $RecentItemsProcessed)) {
+
+                    #Create Analysis Directory
+                    New-Item -Type Directory -Path $RecentItemsProcessed | Out-Null
+
+                    #Process Prefetch and store in analysis directory
+                    $Command = ("{0}\LECmd.exe -d {1} --csv {2}") -f $global:PowerResponse.Config.Path.Bin,$RecentItemsData,$RecentItemsProcessed
+
+                    Invoke-Expression -Command $Command | Out-Null
+
+                } else {
+
+                    #Prevent additional processing of prefetch already analyzed
+                    continue
+                }
+            }
+        }
+    }
+}
+

--- a/Plugins/Import-Computers.ps1
+++ b/Plugins/Import-Computers.ps1
@@ -26,7 +26,7 @@ Run
 .NOTES
     Author: 5yn@x
     Date Created: 11/21/2018
-    Twitter: @5yn@x
+    Twitter: @5ynax
     
     Last Modified By:
     Last Modified Date:

--- a/Plugins/Persistence/Collect-RunKeys.ps1
+++ b/Plugins/Persistence/Collect-RunKeys.ps1
@@ -116,14 +116,14 @@ process {
 
                 "HKLM:\Software\Microsoft\Windows\CurrentVersion\RunServices",
                 "HKLM:\Software\Microsoft\Windows\CurrentVersion\RunServicesOnce",
-                "HKLM:\\Software\Microsoft\Windows\CurrentVersion\Run",
+                "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run",
                 "HKLM:\Software\Microsoft\Windows\CurrentVersion\RunOnce",
                 "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Shell",
                 "HKLM:\Software\Microsoft\Active Setup\Installed Components\KeyName",
                 "HKLM:\Software\Microsoft\Windows\CurrentVersion\explorer\User Shell Folders",
                 "HKLM:\Software\Microsoft\Windows\CurrentVersion\explorer\Shell Folders",
-                "HKLM\SOFTWARE\WOW6432NODE\MICROSOFT\WINDOWS\CURRENTVERSION\RUNONCE",
-                "HKLM\SOFTWARE\WOW6432NODE\MICROSOFT\WINDOWS\CURRENTVERSION\RUN"
+                "HKLM:\SOFTWARE\WOW6432NODE\MICROSOFT\WINDOWS\CURRENTVERSION\RUNONCE",
+                "HKLM:\SOFTWARE\WOW6432NODE\MICROSOFT\WINDOWS\CURRENTVERSION\RUN"
 
                 ) 
 

--- a/Plugins/ProgramExecution/Collect-Prefetch.ps1
+++ b/Plugins/ProgramExecution/Collect-Prefetch.ps1
@@ -66,8 +66,8 @@ process{
         #Scope $PrefetchName
         If (!$PrefetchName){
 
-            #Get Prefetch File Names
-            $PrefetchName = Invoke-Command -Session $Session -ScriptBlock {Get-ChildItem "C:\Windows\Prefetch"} 
+            #Get Prefetch File Names - get only files that have a .pf extension
+            $PrefetchName = Invoke-Command -Session $Session -ScriptBlock {Get-ChildItem "C:\Windows\Prefetch" -Filter "*.pf"} 
 
         }
 

--- a/Plugins/ProgramExecution/Collect-RecentItems.ps1
+++ b/Plugins/ProgramExecution/Collect-RecentItems.ps1
@@ -4,7 +4,7 @@
     Plugin-Name: Collect-RecentItems.ps1
     
 .Description
-    Collects shortcuts from Recent Items (%UserProfile\AppData\Roaming\Microsoft\Windows\Recent)
+    Collects shortcuts (lnk files) from Recent Items (%UserProfile\AppData\Roaming\Microsoft\Windows\Recent)
 
 .EXAMPLE
     Stand Alone Execution
@@ -30,51 +30,65 @@
 param (
 
     [Parameter(Mandatory=$true,Position=0)]
-    [string[]]$ComputerName
+    [string[]]$ComputerName,
+    [Parameter(Mandatory=$false,Position=1)]
+    [string[]]$RecentItemName
     
     )
 
 process {
 
-    foreach ($Comptuer in $ComputerName){
+    #Set $Output for where to store recovered prefetch files
+    $Output= ("{0}\RecentItems\" -f $global:PowerResponse.OutputPath)
 
-        # Create persistent Powershell Session
+    #Create Subdirectory in $global:PowerResponse.OutputPath for storing prefetch
+    If (-not (Test-Path $Output)) {
+        New-Item -Type Directory -Path $Output | Out-Null
+    }   
+
+    foreach ($Computer in $ComputerName){
+
+        #Create persistent Powershell Session
 
         $Session = New-PSSession -ComputerName $Computer -SessionOption (New-PSSessionOption -NoMachineProfile)
 
-        # Get list of users that exist on this process
+        #Get list of users that exist on this process
 
-        Invoke-Command -Session $Session -Scriptblock{
+        $Users = Invoke-Command -Session $Session -Scriptblock{Get-ChildItem "C:\Users\" | ? {@("Public","Default") -NotContains $_.name}}
 
-            $Users = Get-ChildItem "C:\Users\"
+        #For each user, create directory for storing recent files
 
-            #For each user, get contents of recent files (lnk files)
+        foreach ($User in $Users){
 
-            foreach ($User in $Users){
+            $UserOutput = "$Output\$User"
 
-                $RecentItems = Get-ChildItem "C:\Users\$User\AppData\Roaming\Microsoft\Windows\Recent" -ErrorAction SilentlyContinue
-
-                foreach ($Item in $RecentItems) {
-
-                    $OutHash = @{
-
-                        "User" = $User
-                        "Name" = $Item.Name
-                        "Mode" = $Item.Mode
-                        "CreationTime" = $Item.CreationTimeUtc
-                        "ModificationTime" = $Item.LastWriteTimeUtc
-                    }
-
-                    [PSCustomObject]$OutHash | Select User, Name, Mode, CreationTime, ModificationTime
-
-                }
+            #Create User subdirectory 
+            if (-not (Test-Path $UserOutput)) {
+                
+                New-Item -Type Directory -Path $UserOutput | Out-Null
 
             }
 
-        } 
+            #Get all recent files for user
+            if (!$RecentItemName){
+
+                $RecentItemName = Invoke-Command -Session $Session -ScriptBlock {Get-ChildItem "C:\Users\$($args[0])\AppData\Roaming\Microsoft\Windows\Recent" | ? {!$_.PSISContainer}} -ArgumentList $User -ErrorAction SilentlyContinue
+
+            }
+
+            foreach ($File in $RecentItemName){
+
+                #Get recent items file Attributes
+                $CreationTime = Invoke-Command -Session $Session -ScriptBlock {(Get-Item "C:\Users\$($args[0])\AppData\Roaming\Microsoft\Windows\Recent\$($args[1])").CreationTime} -ArgumentList $User,$File
+
+                #Copy specified file to $Output
+                Copy-Item "C:\Users\$User\AppData\Roaming\Microsoft\Windows\Recent\$File" -Destination "$UserOutput\" -FromSession $Session -Force -ErrorAction SilentlyContinue
+
+                #Set original creation time on copied recent items lnk file
+                (Get-Item "$UserOutput\$File").CreationTime = $CreationTime
+            }
+        }
 
         $Session | Remove-PSSession   
-
     }
-
 }

--- a/Plugins/ProgramExecution/Collect-RecentItemsListing.ps1
+++ b/Plugins/ProgramExecution/Collect-RecentItemsListing.ps1
@@ -1,0 +1,80 @@
+<#
+
+.SYNOPSIS
+    Plugin-Name: Collect-RecentItems.ps1
+    
+.Description
+    Collects listing of shortcuts from Recent Items (%UserProfile\AppData\Roaming\Microsoft\Windows\Recent)
+
+.EXAMPLE
+    Stand Alone Execution
+
+    .\Collect-RecentItemsListing.ps1 -ComputerName Test-PC
+
+    Power-Response Execution
+
+    set ComputerName Test-PC
+    run
+
+.NOTES
+    Author: Drew Schmitt
+    Date Created: 3/7/2019
+    Twitter: @5ynax
+    
+    Last Modified By:
+    Last Modified Date:
+    Twitter:
+  
+#>
+
+param (
+
+    [Parameter(Mandatory=$true,Position=0)]
+    [string[]]$ComputerName
+    
+    )
+
+process {
+
+    foreach ($Computer in $ComputerName){
+
+        # Create persistent Powershell Session
+
+        $Session = New-PSSession -ComputerName $Computer -SessionOption (New-PSSessionOption -NoMachineProfile)
+
+        # Get list of users that exist on this process
+
+        Invoke-Command -Session $Session -Scriptblock{
+
+            $Users = Get-ChildItem "C:\Users\"
+
+            #For each user, get contents of recent files (lnk files)
+
+            foreach ($User in $Users){
+
+                $RecentItems = Get-ChildItem "C:\Users\$User\AppData\Roaming\Microsoft\Windows\Recent" -ErrorAction SilentlyContinue
+
+                foreach ($Item in $RecentItems) {
+
+                    $OutHash = @{
+
+                        "User" = $User
+                        "Name" = $Item.Name
+                        "Mode" = $Item.Mode
+                        "CreationTime" = $Item.CreationTimeUtc
+                        "ModificationTime" = $Item.LastWriteTimeUtc
+                    }
+
+                    [PSCustomObject]$OutHash | Select User, Name, Mode, CreationTime, ModificationTime
+
+                }
+
+            }
+
+        } 
+
+        $Session | Remove-PSSession   
+
+    }
+
+}

--- a/Plugins/Triage/Collect-Items.ps1
+++ b/Plugins/Triage/Collect-Items.ps1
@@ -6,8 +6,10 @@
 .Description
     Retrieves a list of items based on user specified item paths or a list stored on disk
     and specified as a list path that points to a CSV or TXT file that contains a list of 
-    item paths. Items will be retrieved and stored on the local system in the 
+    item paths. Items will be retrieved, compressed into a zip archive, and stored on the local system in the 
     Power-Response output path. 
+
+    The output is in ZIP format and has the files inside will have the password "infected"
 
     Note: The CSV and TXT file must be formatted with the first row (and first column)
     being labeled as 'Path'
@@ -60,6 +62,23 @@ param (
 
 process{
 
+    # Verify that 7za executables are located in $global:PowerResponse.Config.Path.Bin
+
+    $7za32 = ("{0}\7za_x86.exe" -f $global:PowerResponse.Config.Path.Bin)
+    $7za64 = ("{0}\7za_x64.exe" -f $global:PowerResponse.Config.Path.Bin)
+
+    $7z64bitTestPath = Get-Item -Path $7za64 -ErrorAction SilentlyContinue
+    $7z32bitTestPath = Get-Item -Path $7za32 -ErrorAction SilentlyContinue
+
+    if (-not $7z64bitTestPath) {
+
+        Throw "64 bit version of 7za.exe not detected in Bin. Place 64bit executable in Bin directory and try again."
+
+    } elseif (-not $7z32bitTestPath) {
+
+        Throw "32 bit version of 7za.exe not detected in Bin. Place 32bit executable in Bin directory and try again."
+    }
+
     # Set $Output for where to store recovered prefetch files
     $Output= ("{0}\ItemCollection\" -f $global:PowerResponse.OutputPath)
 
@@ -74,37 +93,108 @@ process{
         "List" {[string[]]$Items = (Import-CSV $ListPath | Select -ExpandProperty "Path")}
     }
 
-    Write-Host "The items are "$Items
-
     foreach ($Computer in $ComputerName) {
 
         # Create session on remote host (with no profile saved remotely)
         $Session = New-PSSession -ComputerName "$Computer" -SessionOption (New-PSSessionOption -NoMachineProfile)
 
+        #Determine system architecture and select proper 7za.exe executable
+        try {
+         
+            $Architecture = (Get-WmiObject -ComputerName $Computer -Class Win32_OperatingSystem -Property OSArchitecture -ErrorAction Stop).OSArchitecture
+        
+            if ($Architecture -eq "64-bit") {
+
+                $Installexe = $7za64
+
+            } elseif ($Architecture -eq "32-bit") {
+
+                $Installexe = $7za32
+
+            } else {
+            
+                Write-Error ("Unknown system architecture ({0}) detected for {1}. Data was not gathered.)" -f $Architecture, $Computer)
+                Continue
+            }
+
+        } catch {
+        
+         Write-Error ("Unable to determine system architecture for {0}. Data was not gathered." -f $Computer)
+            Continue
+        }
+
+        #Copy 7zip executable to the remote machine for user
+
+        try {
+
+            Copy-Item -Path $Installexe -Destination "C:\ProgramData" -ToSession $Session -Force -ErrorAction Stop
+
+        } catch {
+
+            Throw "Could not copy 7zip to remote machine. Quitting."
+        }
+
         #Collect items
         foreach ($Item in $Items){
-
-            Write-Host "The Item Is" $Item
 
             #Verify that file exists on remote system, if not skip and continue
             $PathVerify = Invoke-Command -Session $Session -ScriptBlock {Test-Path $($args[0])} -ArgumentList $Item
 
             if (!$PathVerify) {
                
-                Write-Error "No item found at $Item. Skipping."
-                continue
+                Write-Error "No item found at $Item. Skipping." -ErrorAction Continue
+                Continue
             }
 
-            #Get Prefetch File Attributes
-            $CreationTime = Invoke-Command -Session $Session -ScriptBlock {(Get-Item $($args[0])).CreationTime} -ArgumentList $Item 
+            #Get Item Attributes, create metadata file, and compress files
+            Invoke-Command -Session $Session -ScriptBlock {
 
-            #Copy specified prefetch file to $Output
-            Copy-Item $Item -Destination "$Output\" -FromSession $Session -Force -ErrorAction SilentlyContinue
+                $MetaData = @{
 
-            #Set original creation time on copied prefetch file
-            (Get-Item ("{0}\{1}" -f $Output, (Split-Path $File -Leaf))).CreationTime = $CreationTime
+                    Item = $($args[0])
+                    CreationTimeUTC = (Get-Item $($args[0])).CreationTimeUtc
+                    ModifiedTime = (Get-Item $($args[0])).LastWriteTimeUtc
+                    AccessTime = (Get-Item $($args[0])).LastAccessTimeUtc
+                } 
+
+                $ExportPath = "C:\ProgramData\{0}_Metadata.csv" -f (Split-Path $($args[0]) -Leaf)
+
+                [PSCustomObject]$MetaData | Export-CSV $ExportPath
+
+                #Create archive of Item and MetaData
+
+                $ArchivePath = "C:\ProgramData\{0}.zip" -f (Split-Path $($args[0]) -Leaf)
+                $Command_Compress = "C:\ProgramData\{0} a -pinfected -tzip {1} {2} {3}" -f ($($args[1]), $ArchivePath, $ExportPath, ($($args[0])))
+
+                Invoke-Expression -Command $Command_Compress | Out-Null
+
+            } -ArgumentList $Item, (Split-Path $Installexe -Leaf)
+
+            #Copy specified archive to $Output
+
+            $ItemPath = "C:\ProgramData\{0}.zip" -f (Split-Path $Item -Leaf)
+
+            Copy-Item -Path $ItemPath -Destination "$Output\" -FromSession $Session -Force -ErrorAction SilentlyContinue
+
+            #Remove created files on remote machine as cleanup
+
+            Invoke-Command -Session $Session -ScriptBlock {
+
+                #Remove the archive
+
+                Remove-Item -Path $ArchivePath -Force 
+                    
+                #Remove the Metadata file
+
+                Remove-Item -Path $ExportPath -Force  
+
+            } -ArgumentList (Split-Path $Installexe -Leaf)
 
         }
+
+        #Remove 7zip
+
+        Invoke-Command -Session $Session -ScriptBlock {Remove-Item -Path ("C:\ProgramData\{0}" -f ($($args[0])))} -Argumentlist (Split-Path $Installexe -Leaf)
 
         #Close PS remoting session
         $Session | Remove-PSSession

--- a/Plugins/Triage/Collect-Items.ps1
+++ b/Plugins/Triage/Collect-Items.ps1
@@ -1,0 +1,112 @@
+<#
+
+.SYNOPSIS
+    Plugin-Name: Collect-Items.ps1
+    
+.Description
+    Retrieves a list of items based on user specified item paths or a list stored on disk
+    and specified as a list path that points to a CSV or TXT file that contains a list of 
+    item paths. Items will be retrieved and stored on the local system in the 
+    Power-Response output path. 
+
+    Note: The CSV and TXT file must be formatted with the first row (and first column)
+    being labeled as 'Path'
+
+.EXAMPLE
+    Stand Alone Execution
+
+    .\Collect-Items.ps1 -ComputerName Test-PC -ItemPath C:\Power-Response\Power-Response.ps1
+
+    OR
+
+    .\Collect-Items.ps1 -ComputerName Test-PC -ListPath C:\Tools\ItemPaths.csv
+
+    Power-Response Execution
+
+    Set ComputerName Test-PC
+    Set ItemPath C:\Power-Response\Power-Response.ps1
+    run
+    
+    OR
+
+    Set ComputerName Test-PC
+    Set ListPath C:\Tools\ItemPaths.csv
+    run
+
+.NOTES
+    Author: Drew Schmitt
+    Date Created: 3/15/2019
+    Twitter: @5ynax
+    
+    Last Modified By:
+    Last Modified Date:
+    Twitter:
+  
+#>
+
+param (
+
+    [Parameter(ParameterSetName = "Items", Position = 0, Mandatory = $true)]
+    [Parameter(ParameterSetName = "List", Position = 0, Mandatory = $true)]
+    [string[]]$ComputerName,
+
+    [Parameter(ParameterSetName = "Items", Position = 1, Mandatory = $true)]
+    [string[]]$ItemPath,
+
+    [Parameter(ParameterSetName = "List", Position = 1, Mandatory = $true)]
+    [string]$ListPath
+
+    )
+
+process{
+
+    # Set $Output for where to store recovered prefetch files
+    $Output= ("{0}\ItemCollection\" -f $global:PowerResponse.OutputPath)
+
+    # Create Subdirectory in $global:PowerResponse.OutputPath for storing prefetch
+    If (-not (Test-Path $Output)) {
+        New-Item -Type Directory -Path $Output | Out-Null
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+
+        "Items" {[string[]]$Items = $ItemPath}
+        "List" {[string[]]$Items = (Import-CSV $ListPath | Select -ExpandProperty "Path")}
+    }
+
+    Write-Host "The items are "$Items
+
+    foreach ($Computer in $ComputerName) {
+
+        # Create session on remote host (with no profile saved remotely)
+        $Session = New-PSSession -ComputerName "$Computer" -SessionOption (New-PSSessionOption -NoMachineProfile)
+
+        #Collect items
+        foreach ($Item in $Items){
+
+            Write-Host "The Item Is" $Item
+
+            #Verify that file exists on remote system, if not skip and continue
+            $PathVerify = Invoke-Command -Session $Session -ScriptBlock {Test-Path $($args[0])} -ArgumentList $Item
+
+            if (!$PathVerify) {
+               
+                Write-Error "No item found at $Item. Skipping."
+                continue
+            }
+
+            #Get Prefetch File Attributes
+            $CreationTime = Invoke-Command -Session $Session -ScriptBlock {(Get-Item $($args[0])).CreationTime} -ArgumentList $Item 
+
+            #Copy specified prefetch file to $Output
+            Copy-Item $Item -Destination "$Output\" -FromSession $Session -Force -ErrorAction SilentlyContinue
+
+            #Set original creation time on copied prefetch file
+            (Get-Item ("{0}\{1}" -f $Output, (Split-Path $File -Leaf))).CreationTime = $CreationTime
+
+        }
+
+        #Close PS remoting session
+        $Session | Remove-PSSession
+    }
+}


### PR DESCRIPTION
fixes #226 

When reviewing, there is a terminating error problem that appears to be at the framework level. Reproduce by listing multiple files and make one of them not exist but have other files to process afterwards. when running in the framework, the write-error for non-existent files terminates the foreach loop, while running as standalone does not.