### PR TITLE
Fixed rootkeys in Import-Config

### DIFF
--- a/Power-Response.ps1
+++ b/Power-Response.ps1
@@ -156,7 +156,7 @@ function Get-Menu {
 function Import-Config {
     param (
         [String]$Path = ('{0}\Config.psd1' -f $PSScriptRoot),
-        [String[]]$RootKeys = @('AdminUserName','HashAlgorithm', 'OutputType', 'PromptText', 'AutoAnalyze', 'Path', 'UserName')
+        [String[]]$RootKeys = @('AdminUserName','HashAlgorithm', 'OutputType', 'PromptText', 'AutoAnalyze', 'Path', 'PSSession')
     )
 
     process {


### PR DESCRIPTION
Rootkeys references UserName, replaced with PSSession to resolve error that came from manual merge from last commit.