### PR TITLE
Removed Bin Location Set

### DIFF
--- a/Power-Response.ps1
+++ b/Power-Response.ps1
@@ -1484,12 +1484,6 @@ if ('UserInput' -as [Type] -ne $null) {
     }
 }
 
-# Save the execution location
-$SavedLocation = Get-Location
-
-# Set the location to Bin folder to allow easy asset access
-Set-Location -Path (Get-PRPath -Bin)
-
 # Get the $Plugins directory item
 $Plugins = Get-Item -Path (Get-PRPath -Plugins)
 
@@ -1559,9 +1553,6 @@ try {
         } while (!$global:PowerResponse.Location.PSIsContainer)
     } while ($True)
 } finally {
-    # Set location back to original $SavedLocation
-    Set-Location -Path $SavedLocation
-
     # Write a log to indicate framework exit
     Write-Log -Message 'Exited the Power-Response framework'
 


### PR DESCRIPTION
Removed code to set the PowerShell location to the Bin folder to allow easy Bin asset access.
Nothing we've used thus far has leveraged this, and it is easy to `Get-PRPath -Bin` to get the full path.