### PR TITLE
Chrome Extension Enumeration

### DIFF
--- a/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
+++ b/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
@@ -49,7 +49,7 @@ begin {
             if ($Response.Content -Match '<title>(.+) - Chrome Web Store</title>' -and $Matches.Count -gt 1) {
                 return $Matches[1]
             } else {
-                return 'Unknown Extension'
+                return ''
             }
         }
     }

--- a/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
+++ b/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
@@ -65,7 +65,5 @@ process {
     # Gather the extension list
     $Extensions = Invoke-Command -Session $Session -ScriptBlock { Get-Item -Path $using:ChromeExtensions }
 
-    # $Extensions | Foreach-Object { Add-Member -InputObject $PSItem -NotePropertyName 'ExtensionName' -NotePropertyValue () }
-
     return $Extensions | Select-Object -Property @{Name='ExtensionID'; Expression={$PSItem.Name}},@{Name='ExtensionName'; Expression={Resolve-ChromeExtension -ExtensionID $PSItem.Name}},@{Name='User'; Expression={$PSItem.FullName -Split '\\' | Select-Object -First 1 -Skip 2}},@{Name='Path'; Expression={$PSItem.FullName}},'LastWriteTime','PSComputerName'
 }

--- a/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
+++ b/Plugins/Persistence/Retrieve-ChromeExtensions.ps1
@@ -1,0 +1,71 @@
+<#
+
+.SYNOPSIS
+    Plugin-Name: Retrieve-ChromeExtensions.ps1
+    
+.Description
+    Retrieves the Chrome (and Chromium) extensions listing and translates the extensions to their common name.
+
+.EXAMPLE
+
+    Power-Response Execution
+
+    set ComputerName Test-PC
+    run
+
+.NOTES
+    Author: Gavin Prentice
+    Date Created: 10/25/2019
+    Twitter: @Valrkey
+    
+    Last Modified By:
+    Last Modified Date:
+    Twitter:
+  
+#>
+
+param (
+    [Parameter(Mandatory=$true,Position=0)]
+    [System.Management.Automation.Runspaces.PSSession[]]$Session
+)
+
+begin {
+    function Resolve-ChromeExtension {
+        param (
+            [Parameter(ValueFromPipeline=$true)]
+            [String]$ExtensionID
+        )
+
+        process {
+            $Response = @{}
+            try {
+                $Response = Invoke-WebRequest -Uri "https://chrome.google.com/webstore/detail/$ExtensionID"
+            } catch [System.Net.WebException] {
+                Write-Verbose -Message "ExtensionID: $ExtensionID is unknown"
+            } catch {
+                Write-Warning -Message "An unexpected Invoke-WebRequest error has occurred: $PSItem"
+            }
+
+            if ($Response.Content -Match '<title>(.+) - Chrome Web Store</title>' -and $Matches.Count -gt 1) {
+                return $Matches[1]
+            } else {
+                return 'Unknown Extension'
+            }
+        }
+    }
+}
+
+process {
+    # Get all the chome extensions
+    $ChromeExtensions = @(
+        'C:\Users\*\AppData\Local\Google\Chrome\User Data\Default\Extensions\*',
+        'C:\Users\*\AppData\Local\Chromium\User Data\Default\Extensions\*'
+    )
+
+    # Gather the extension list
+    $Extensions = Invoke-Command -Session $Session -ScriptBlock { Get-Item -Path $using:ChromeExtensions }
+
+    # $Extensions | Foreach-Object { Add-Member -InputObject $PSItem -NotePropertyName 'ExtensionName' -NotePropertyValue () }
+
+    return $Extensions | Select-Object -Property @{Name='ExtensionID'; Expression={$PSItem.Name}},@{Name='ExtensionName'; Expression={Resolve-ChromeExtension -ExtensionID $PSItem.Name}},@{Name='User'; Expression={$PSItem.FullName -Split '\\' | Select-Object -First 1 -Skip 2}},@{Name='Path'; Expression={$PSItem.FullName}},'LastWriteTime','PSComputerName'
+}

--- a/Plugins/Triage/Triage-Persistence.ps1
+++ b/Plugins/Triage/Triage-Persistence.ps1
@@ -57,5 +57,6 @@ process{
     Invoke-PRPlugin -Name Collect-WMIFilters.ps1 -Session $Session
     Invoke-PRPlugin -Name Collect-LocalUsers.ps1 -Session $Session
     Invoke-PRPlugin -Name Collect-UserProfileListing.ps1 -Session $Session
+    Invoke-PRPlugin -Name Retrieve-ChromeExtensions.ps1 -Session $Session
     # End plugin logic
 }


### PR DESCRIPTION
Plugin requested by @mikeclemson.

@5ynax: This plugin is an edge case for what we have written so far so I'm not exactly sure how to fit this to the plugin template we have going so far. It doesn't copy files back so normally I'd call this a Collect plugin, but it requires post-processing of sending a bunch of web requests to resolve the Chrome extension IDs with Google. Right now I have it as a Retrieve plugin to allow for the web requests to be generated on the analyst machine rather than the machine under investigation.